### PR TITLE
Fix for nfdump version 1.75-release still outputting header line when using -q argument

### DIFF
--- a/nfdump2clickhouse.py
+++ b/nfdump2clickhouse.py
@@ -573,7 +573,7 @@ def main():
             if not sig_received:
                 if len(import_files)>0:
                     imp = import_files.pop()
-                    pool.apply_async(convert, args=(imp, db_tbl, flowsrc, args.u),
+                    pool.apply_async(convert, args=(imp, db_tbl, flowsrc, args.u, logger.level),
                                       callback=completed_callback,
                                       error_callback=error_callback)
             else:
@@ -585,7 +585,7 @@ def main():
         init_sub_nr = workers if workers<len(import_files) else len(import_files)
         for i in range(0, init_sub_nr):
             f = import_files.pop()
-            pool.apply_async(convert, args=(f, db_tbl, flowsrc, args.u),
+            pool.apply_async(convert, args=(f, db_tbl, flowsrc, args.u, logger.level),
                               callback=completed_callback,
                               error_callback=error_callback)
         try:

--- a/nfdump2clickhouse.py
+++ b/nfdump2clickhouse.py
@@ -386,6 +386,7 @@ def convert(src_file: str,
             header = fp.readline()
             if header.startswith('firstSeen'):
                 skip_rows = 1
+                logger.debug("csv exported by nfdump still contains header line, skipping")
 
         with pyarrow.csv.open_csv(input_file=tmp_filename,
                                   read_options=pyarrow.csv.ReadOptions(
@@ -584,7 +585,7 @@ def main():
         init_sub_nr = workers if workers<len(import_files) else len(import_files)
         for i in range(0, init_sub_nr):
             f = import_files.pop()
-            pool.apply_async(convert, args=(f, db_tbl, flowsrc, args.u, logging.DEBUG, '.'),
+            pool.apply_async(convert, args=(f, db_tbl, flowsrc, args.u),
                               callback=completed_callback,
                               error_callback=error_callback)
         try:

--- a/nfdump2clickhouse.py
+++ b/nfdump2clickhouse.py
@@ -573,7 +573,7 @@ def main():
             if not sig_received:
                 if len(import_files)>0:
                     imp = import_files.pop()
-                    pool.apply_async(convert, args=(imp, db_tbl, flowsrc),
+                    pool.apply_async(convert, args=(imp, db_tbl, flowsrc, args.u),
                                       callback=completed_callback,
                                       error_callback=error_callback)
             else:


### PR DESCRIPTION
nfdump version 1.75-release still outputs a header line with a csv export even when instructed not to do so with a -q argument. 
This screws up conversion to parquet since then every column is assumed to be a string.
This fix always checks the first line of the exported csv to check it is not a header. 
If it is a header, the first line is skipped by setting skip_rows to 1 (default 0) for the csv reader.
